### PR TITLE
feat: add mcp() hook with okta-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Okta: identity provider integration and MCP server
+(`okta-mcp-server` via npm) for AI-driven user and application management.
 
 ## Contributing
 
@@ -36,6 +37,7 @@ TODO: Add a short summary of this module.
 ##### p6df-okta/init.zsh
 
 - `p6df::modules::okta::deps()`
+- `p6df::modules::okta::mcp()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -11,3 +11,17 @@ p6df::modules::okta::deps() {
     p6m7g8-dotfiles/p6common
   )
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::okta::mcp()
+#
+#>
+######################################################################
+p6df::modules::okta::mcp() {
+
+  p6_js_npm_global_install "okta-mcp-server"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::okta::mcp()` installing `okta-mcp-server` via npm
- Regenerated README with updated function list and Summary

## Test plan
- [ ] `p6df::modules::okta::mcp()` installs `okta-mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)