### PR TITLE
feat: add home::symlinks() for claude skills

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -16,6 +16,21 @@ p6df::modules::okta::deps() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::okta::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+p6df::modules::okta::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/RedCupIT/okta-claude-skill/skills/okta"                                                   "$HOME/.claude/skills/okta"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::okta::mcp()
 #
 #>


### PR DESCRIPTION
## Summary

- Adds `home::symlinks()` function to symlink Claude Code skills into `~/.claude/skills/`

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)