### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -44,3 +44,19 @@ p6df::modules::okta::mcp() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words okta $OKTA_ORG_URL = p6df::modules::okta::profile::mod()
+#
+#  Returns:
+#	words - okta $OKTA_ORG_URL
+#
+#  Environment:	 OKTA_ORG_URL
+#>
+######################################################################
+p6df::modules::okta::profile::mod() {
+
+  p6_return_words 'okta' '$OKTA_ORG_URL'
+}

--- a/init.zsh
+++ b/init.zsh
@@ -58,5 +58,5 @@ p6df::modules::okta::mcp() {
 ######################################################################
 p6df::modules::okta::profile::mod() {
 
-  p6_return_words 'okta' '$OKTA_ORG_URL'
+  p6_return_words 'okta' "$"
 }


### PR DESCRIPTION
## What
Add `profile::mod` to p6df-okta using `p6_return_words` with word and variable as separate quoted arguments.

## Why
Consistent quoting convention for `p6_return_words` calls across all p6df modules.

## Test plan
- Verify `p6df::modules::okta::profile::mod` returns two words: `okta` and the value of `$OKTA_ORG_URL`
- Load module in zsh and confirm no errors

## Dependencies
None