### PR TITLE
fix(prompt): set OKTA_ORG_URL env var in profile::mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ p6df module for Okta: identity provider integration and MCP server
 
 - `p6df::modules::okta::deps()`
 - `p6df::modules::okta::mcp()`
+- `words okta $OKTA_ORG_URL = p6df::modules::okta::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -58,5 +58,5 @@ p6df::modules::okta::mcp() {
 ######################################################################
 p6df::modules::okta::profile::mod() {
 
-  p6_return_words 'okta' "$"
+  p6_return_words 'okta' '$OKTA_ORG_URL'
 }


### PR DESCRIPTION
## What
Replace placeholder `"$"` with `'$OKTA_ORG_URL'` in `p6df::modules::okta::profile::mod()` and update README.

## Why
The prompt word list was missing the actual environment variable, causing the prompt to display nothing useful.

## Test plan
- Inspected change manually

## Dependencies
None