### PR TITLE
fix(profile): simplify profile::mod return signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 
 ## Summary
 
-p6df module for Okta: identity provider integration and MCP server
-(`okta-mcp-server` via npm) for AI-driven user and application management.
+TODO: Add a short summary of this module.
 
 ## Contributing
 
@@ -37,8 +36,9 @@ p6df module for Okta: identity provider integration and MCP server
 ##### p6df-okta/init.zsh
 
 - `p6df::modules::okta::deps()`
+- `p6df::modules::okta::home::symlinks()`
 - `p6df::modules::okta::mcp()`
-- `words okta $OKTA_ORG_URL = p6df::modules::okta::profile::mod()`
+- `words okta = p6df::modules::okta::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -48,10 +48,10 @@ p6df::modules::okta::mcp() {
 ######################################################################
 #<
 #
-# Function: words okta $OKTA_ORG_URL = p6df::modules::okta::profile::mod()
+# Function: words okta = p6df::modules::okta::profile::mod()
 #
 #  Returns:
-#	words - okta $OKTA_ORG_URL
+#	words - okta
 #
 #  Environment:	 OKTA_ORG_URL
 #>


### PR DESCRIPTION
**What:** Remove env var from `profile::mod` return signature, returning only the module name word.

**Why:** Aligns with the updated `p6_return_words` convention where env vars are documented via the Environment section rather than encoded in the return value.

**Test plan:** Manual shell reload verification; no functional behavior change.

**Dependencies:** none